### PR TITLE
Fix: incomplete URL substring sanitization (4 code scanning alerts)

### DIFF
--- a/sausage_bot/cogs/rss.py
+++ b/sausage_bot/cogs/rss.py
@@ -842,7 +842,8 @@ class RSSfeed(commands.Cog):
             return
         logger.debug('Adding feed to db')
         feed_type = 'podcast'
-        if 'acast.com' in feed_link and 'feeds.acast.com' not in feed_link:
+        if net_io.url_hostname_matches(feed_link, 'acast.com') and \
+                not net_io.url_hostname_matches(feed_link, 'feeds.acast.com'):
             logger.debug('Found Acast, but not the rss feed. Changing url')
             base_feed_url = 'https://feeds.acast.com/public/shows/{}'
             feed_link = re.sub(r'/episodes.*', '', feed_link)

--- a/sausage_bot/util/feeds_core.py
+++ b/sausage_bot/util/feeds_core.py
@@ -157,7 +157,8 @@ async def check_feed_validity(url_in, mock_file=None):
         return True
     sample_item = None
     logger.debug(f'Checking `url_in`: {url_in}')
-    if 'acast.com' in url_in and 'feeds.acast.com' not in url_in:
+    if net_io.url_hostname_matches(url_in, 'acast.com') and \
+            not net_io.url_hostname_matches(url_in, 'feeds.acast.com'):
         logger.debug('Found Acast, but not the rss feed. Changing url')
         base_feed_url = 'https://feeds.acast.com/public/shows/{}'
         url_in = re.sub(r'/episodes.*', '', url_in)

--- a/sausage_bot/util/net_io.py
+++ b/sausage_bot/util/net_io.py
@@ -4,6 +4,7 @@
 import discord
 import re
 import aiohttp
+from urllib.parse import urlparse
 from random import choice
 import requests
 from datetime import datetime
@@ -39,6 +40,26 @@ try:
 except (SpotifyOauthError, ConnectionError) as _error:
     _spotipy = None
     logger.error(f'Error when connecting to Spotify: {_error}')
+
+
+def url_hostname_matches(url_in, domain):
+    '''
+    Safely check if `url_in`'s hostname is `domain` or a subdomain of it.
+
+    This avoids naive substring checks like `'youtube.com' in url`, which
+    can be tricked by URLs such as `https://evil.com/youtube.com` or
+    `https://notyoutube.com.evil.net` (incomplete URL substring
+    sanitization).
+    '''
+    try:
+        hostname = urlparse(url_in).hostname
+    except ValueError:
+        return False
+    if not hostname:
+        return False
+    hostname = hostname.lower()
+    domain = domain.lower()
+    return hostname == domain or hostname.endswith(f'.{domain}')
 
 
 async def fetch_random_user_agent():
@@ -874,7 +895,7 @@ async def get_page_hash(url, debug=False):
         return None
     desc = None
     soup = BeautifulSoup(req, features='html.parser')
-    if desc is None and 'youtube.com' in url:
+    if desc is None and url_hostname_matches(url, 'youtube.com'):
         logger.debug(f'Trying yt check on {url}')
         ydl_opts = {
             'simulate': True,
@@ -885,7 +906,7 @@ async def get_page_hash(url, debug=False):
         with YoutubeDL(ydl_opts) as ydl:
             yt_info = ydl.extract_info(url)
         desc = yt_info['fulltitle']
-    if desc is None and 'open.spotify.com' in url:
+    if desc is None and url_hostname_matches(url, 'open.spotify.com'):
         logger.debug(f'Trying spotify check on {url}')
         try:
             check_if_spotify = soup.find('meta', attrs={'content': 'Spotify'})


### PR DESCRIPTION
## Fixes

Fixes all 4 open code scanning alerts of type `py/incomplete-url-substring-sanitization`:

- #3 `sausage_bot/util/feeds_core.py` (acast.com check)
- #6 `sausage_bot/cogs/rss.py` (acast.com check)
- #7 `sausage_bot/util/net_io.py` (youtube.com check)
- #8 `sausage_bot/util/net_io.py` (open.spotify.com check)

## Problem

These checks used naive substring matching, e.g.:

```python
if 'youtube.com' in url:
```

This can be bypassed by URLs where the domain string appears somewhere other than the actual hostname, e.g. `https://evil.com/youtube.com` or `https://notyoutube.com.evil.net`, potentially causing the bot to misidentify the source of a URL.

## Fix

Added a new helper `url_hostname_matches(url, domain)` in `net_io.py` that uses `urllib.parse.urlparse` to extract the actual hostname and compares it against the expected domain (exact match or proper subdomain match). Updated all four call sites to use this helper instead of substring checks.

## Testing

- All modified files pass `python -m py_compile`.
- Behavior for legitimate URLs (e.g. `https://www.youtube.com/watch?v=...`, `https://open.spotify.com/episode/...`, `https://feeds.acast.com/...`) is unchanged.
- Malicious/edge-case URLs like `https://evil.com/youtube.com` no longer match.

---
Change ordered by geirawsm, compiled by Claude. geirawsm takes full responsilibity for code.